### PR TITLE
Mantenimiento 2023-01-30 (version 2.0.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -54,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, phpstan
         env:
@@ -82,7 +82,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, psalm
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,7 +2,7 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.26.0" installed="4.26.0" location="./tools/psalm" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.14" installed="1.9.14" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.6.0" installed="5.6.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,7 +28,7 @@ return (new PhpCsFixer\Config())
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -36,6 +36,7 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 - 2022 PhpCfdi - https://www.phpcfdi.com/
+Copyright (c) 2020 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/phpcfdi/resources-sat-xml-generator resources-sat-x
 cd resources-sat-xml-generator
 composer install
 php bin/resources-sat-xml-generator fetch:sat xml-resources/ all
-``` 
+```
 
 ## Uso básico
 
@@ -51,7 +51,7 @@ php bin/resources-sat-xml-generator fetch http://...
 
 En el repositorio se encuentran los archivos para construir la *imagen* de docker y así ejecutar el *contenedor*.
 
-Para construir la imagen con el nombre `resources-sat-xml-generator`: 
+Para construir la imagen con el nombre `resources-sat-xml-generator`:
 
 ```shell
 git clone https://github.com/phpcfdi/resources-sat-xml-generator.git
@@ -122,7 +122,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: http://img.shields.io/badge/source-phpcfdi/resources--sat--xml--generator-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/resources-sat-xml-generator?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/resources-sat-xml-generator?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/resources-sat-xml-generator/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/resources-sat-xml-generator/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/resources-sat-xml-generator/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/resources-sat-xml-generator/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/resources-sat-xml-generator?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
+## Versión 2.0.1 2023-01-30
+
+- Se corrige un posible bug en `Downloader` al dividir un texto en dos partes.
+  La segunda parte podría no existir y no estaba tratado correctamente.
+- Se le da mantenimiento a el proyecto:
+  - Actualización de licencia. Feliz 2023.
+  - Actualización del emblema de construcción.
+  - Se agrega PHP 8.2 a la matrix de pruebas.
+  - Se usa PHP 8.2 en la mayoría de los flujos de trabajo.
+  - Se actualizan las herramientas de desarrollo.
+  - Se actualizan las configuraciones de revisión y corrección de estilo de código.
+
 ## Versión 2.0.0 2022-03-06
 
 Se actualiza la versión de `eclipxe/xmlresourceretriever` a `2.0`.
@@ -25,7 +37,7 @@ Se actualizan las herramientas de desarrollo.
 
 ## Unreleased 2022-02-22
 
-Se corrige el archivo de configuración de `psalm.xml.dist` porque el atributo `totallytyped` ha sido deprecado. 
+Se corrige el archivo de configuración de `psalm.xml.dist` porque el atributo `totallytyped` ha sido deprecado.
 
 ## Versión 1.2.0 2022-01-02
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-12 based) coding standard.</description>
+    <description>The EngineWorks (PSR-2 based) coding standard.</description>
 
     <file>bin</file>
     <file>src</file>

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -54,7 +54,11 @@ final class Downloader implements DownloaderInterface
     {
         foreach ($overridePairs as $overridePair) {
             $overridePair = (string) preg_replace('/\s+/', ' ', $overridePair);
-            [$source, $override] = explode(' ', $overridePair, 2);
+            $overridePairParts = explode(' ', $overridePair, 2);
+            if (! isset($overridePairParts[0], $overridePairParts[1])) {
+                continue;
+            }
+            [$source, $override] = $overridePairParts;
             $this->setOverride($source, $override);
         }
     }


### PR DESCRIPTION
- Se corrige un posible bug en `Downloader` al dividir un texto en dos partes. La segunda parte podría no existir y no estaba tratado correctamente.
- Se le da mantenimiento a el proyecto:
  - Actualización de licencia. Feliz 2023.
  - Actualización del emblema de construcción.
  - Se agrega PHP 8.2 a la matrix de pruebas.
  - Se usa PHP 8.2 en la mayoría de los flujos de trabajo.
  - Se actualizan las herramientas de desarrollo.
  - Se actualizan las configuraciones de revisión y corrección de estilo de código.
