### PR TITLE
Mantenimiento 2024-01-22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: PHPStan
-        run: phpstan analyse --no-progress --verbose
+        run: phpstan analyse --no-progress
 
   psalm:
     name: Code analysis (psalm)
@@ -103,7 +103,7 @@ jobs:
         run: psalm --no-progress --output-format=github
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -114,7 +114,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:
@@ -131,4 +131,4 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
-        run: vendor/bin/phpunit --testdox --verbose
+        run: vendor/bin/phpunit --testdox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, cs2pr, phpstan
         env:
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, cs2pr, psalm
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.9.14" installed="1.9.14" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.6.0" installed="5.6.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpcs" version="^3.8.1" installed="3.8.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.8.1" installed="3.8.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.48.0" installed="3.48.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.56" installed="1.10.56" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.20.0" installed="5.20.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,7 +12,7 @@ build:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: php -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-clover=build/coverage.clover
+          - command: php -dxdebug.mode=coverage vendor/bin/phpunit --coverage-clover=build/coverage.clover
             coverage:
               file: build/coverage.clover
               format: clover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-cli
+FROM php:8.3-cli
 
 COPY . /opt/generator
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 - 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2020 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/resources-sat-xml-generator
+++ b/bin/resources-sat-xml-generator
@@ -5,4 +5,5 @@ declare(strict_types=1);
 
 include __DIR__ . '/../vendor/autoload.php';
 
+/** @noinspection PhpUnhandledExceptionInspection */
 exit((new PhpCfdi\ResourcesSatXmlGenerator\CLI\Application())->run());

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "php": ">=8.3",
         "ext-json": "*",
         "eclipxe/xmlresourceretriever": "^2.0.1",
-        "symfony/http-client": "^6.0",
-        "symfony/console": "^6.0"
+        "symfony/http-client": "^7.0",
+        "symfony/console": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "^10.5",
         "fakerphp/faker": "^1.17",
-        "symfony/finder": "^6.0"
+        "symfony/finder": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,12 +48,12 @@
         ],
         "dev:test": [
             "@dev:check-style",
-            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpunit --testdox --stop-on-failure",
             "@php tools/phpstan analyse --no-progress",
             "@php tools/psalm --no-progress"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/phpcfdi/resources-sat-xml-generator/issues"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-json": "*",
         "eclipxe/xmlresourceretriever": "^2.0.1",
         "symfony/http-client": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/phpcfdi/resources-sat-xml-generator/issues"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-json": "*",
         "eclipxe/xmlresourceretriever": "^2.0.1",
         "symfony/http-client": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/phpcfdi/resources-sat-xml-generator/issues"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "eclipxe/xmlresourceretriever": "^2.0.1",
         "symfony/http-client": "^6.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 ## Versión 3.0.0 2024-01-22
 
-- Se actualiza la versión mínima de PHP a 8.1.
+- Se actualiza la versión mínima de PHP a 8.2.
 
 ## Mantenimiento 2024-01-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
+## Versión 3.0.0 2024-01-22
+
+- Se actualiza la versión mínima de PHP a 8.1.
+
 ## Mantenimiento 2024-01-22
 
 - Se actualiza la imagen de docker para que esté basada en PHP 8.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
+Importante: **Cambiar la versión en `Application::__construct`**. 
+
 ## Versión 3.0.0 2024-01-22
 
 - Se actualiza la versión mínima de PHP a 8.3.
+- Se corrigen los problemas encontrados por PhpStorm.
+- Se establece la versión correcta en `Application::__construct`.
 
 ## Mantenimiento 2024-01-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 ## Versión 3.0.0 2024-01-22
 
-- Se actualiza la versión mínima de PHP a 8.2.
+- Se actualiza la versión mínima de PHP a 8.3.
 
 ## Mantenimiento 2024-01-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
+## Mantenimiento 2024-01-22
+
+- Se actualiza la imagen de docker para que esté basada en PHP 8.3.
+- Se cambia el archivo de licencia. ¡Feliz 2024!
+- Se corrige el ancla del proyecto en el archivo `CONTRIBUTING.md`.
+- Se actualiza el archivo de configuración de `php-cs-fixer`.
+- Se actualizan los flujos de trabajo de GitHub:
+  - Se agrega PHP 8.3 a la matriz de pruebas.
+  - Se ejecutan los flujos de trabajo en PHP 8.3.
+  - Se permite ejecutar manualmente el flujo de trabajo.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 2.0.1 2023-01-30
 
 - Se corrige un posible bug en `Downloader` al dividir un texto en dos partes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 - Se corrige un posible bug en `Downloader` al dividir un texto en dos partes.
   La segunda parte podría no existir y no estaba tratado correctamente.
-- Se le da mantenimiento a el proyecto:
+- Se le da mantenimiento al proyecto:
   - Actualización de licencia. Feliz 2023.
   - Actualización del emblema de construcción.
   - Se agrega PHP 8.2 a la matrix de pruebas.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,3 +7,7 @@ Liste en este archivo los posibles cambios futuros e ideas pendientes.
 A la fecha 2024-01-22 la herramienta `phpcs` no detecta correctamente los tipos en las constantes de PHP 8.3, 
 por lo que no se han agregado. En cuanto se corrija este problema, se debe agregar el tipo de datos.
 Por ejemplo en `PhpCfdi\ResourcesSatXmlGenerator\CLI\FetchSatCommand::NS_REGISTRY`.
+
+## Migrar de Scrutinizer-CI a SonarCloud
+
+La migración de *Scrutinizer-CI* a *SonarCloud* es deseable porque tiene mejores métricas y visualización de cobertura de código.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,3 @@
 # phpcfdi/resources-sat-xml-generator To Do List
 
-## Cambio de versión mínima de PHP a 8.0
-
-Este proyecto podría utilizar todas las ventajas del lenguaje en una versión más reciente.
-Se podría utilizar `rector` para hacer esta migración.
-
+Liste en este archivo los posibles cambios futuros e ideas pendientes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,3 +1,9 @@
 # phpcfdi/resources-sat-xml-generator To Do List
 
 Liste en este archivo los posibles cambios futuros e ideas pendientes.
+
+## Tipo de datos de constantes
+
+A la fecha 2024-01-22 la herramienta `phpcs` no detecta correctamente los tipos en las constantes de PHP 8.3, 
+por lo que no se han agregado. En cuanto se corrija este problema, se debe agregar el tipo de datos.
+Por ejemplo en `PhpCfdi\ResourcesSatXmlGenerator\CLI\FetchSatCommand::NS_REGISTRY`.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,9 +9,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src/</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -10,7 +10,7 @@ class Application extends SymfonyApplication
 {
     public function __construct()
     {
-        parent::__construct('resources-sat-xml-generator', '1.2.0');
+        parent::__construct('resources-sat-xml-generator', '3.0.0');
         $this->add(new FetchSatCommand());
         $this->add(new FetchCommand());
     }

--- a/src/CLI/FetchCommand.php
+++ b/src/CLI/FetchCommand.php
@@ -17,6 +17,7 @@ final class FetchCommand extends Command
 {
     protected static $defaultName = 'fetch:urls';
 
+    /** @noinspection PhpMissingParentCallCommonInspection */
     protected function configure(): void
     {
         $this->setDescription('Fetch xsd or xslt resources and store them on destination folder');
@@ -29,7 +30,8 @@ final class FetchCommand extends Command
         );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): int
+    /** @noinspection PhpMissingParentCallCommonInspection */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var string $destinationPath */
         $destinationPath = $input->getArgument('destination-path');

--- a/src/CLI/FetchCommand.php
+++ b/src/CLI/FetchCommand.php
@@ -15,7 +15,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class FetchCommand extends Command
 {
-    protected static $defaultName = 'fetch:urls';
+    /** @noinspection PhpMissingParentCallCommonInspection */
+    public static function getDefaultName(): string
+    {
+        return 'fetch:urls';
+    }
 
     /** @noinspection PhpMissingParentCallCommonInspection */
     protected function configure(): void

--- a/src/CLI/FetchSatCommand.php
+++ b/src/CLI/FetchSatCommand.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PhpCfdi\ResourcesSatXmlGenerator\CLI;
 
-use Exception;
 use PhpCfdi\ResourcesSatXmlGenerator\Fetcher;
 use PhpCfdi\ResourcesSatXmlGenerator\NsRegistry\NsRegistry;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +20,7 @@ final class FetchSatCommand extends Command
 
     protected static $defaultName = 'fetch:sat';
 
+    /** @noinspection PhpMissingParentCallCommonInspection */
     protected function configure(): void
     {
         $this->setDescription('Fetch the XSD collection files from SAT Registry, see ' . self::NS_REGISTRY);
@@ -34,13 +35,14 @@ final class FetchSatCommand extends Command
         );
     }
 
+    /** @noinspection PhpMissingParentCallCommonInspection */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var string|null $type */
         $type = $input->getArgument('type');
         $type = strtolower($type ?? '' ?: 'all');
         if (! in_array($type, ['all', 'xsd', 'xslt'], true)) {
-            throw new Exception('Argument type (optional) must be one of all, xsd or xslt');
+            throw new RuntimeException('Argument type (optional) must be one of all, xsd or xslt');
         }
         $downloadXsd = in_array($type, ['all', 'xsd'], true);
         $downloadXslt = in_array($type, ['all', 'xslt'], true);

--- a/src/CLI/FetchSatCommand.php
+++ b/src/CLI/FetchSatCommand.php
@@ -18,7 +18,11 @@ final class FetchSatCommand extends Command
 {
     public const NS_REGISTRY = 'https://raw.githubusercontent.com/phpcfdi/sat-ns-registry/master/complementos_v1.json';
 
-    protected static $defaultName = 'fetch:sat';
+    /** @noinspection PhpMissingParentCallCommonInspection */
+    public static function getDefaultName(): string
+    {
+        return 'fetch:sat';
+    }
 
     /** @noinspection PhpMissingParentCallCommonInspection */
     protected function configure(): void

--- a/src/CLI/FetchSatCommand.php
+++ b/src/CLI/FetchSatCommand.php
@@ -45,7 +45,7 @@ final class FetchSatCommand extends Command
         $downloadXsd = in_array($type, ['all', 'xsd'], true);
         $downloadXslt = in_array($type, ['all', 'xslt'], true);
         /** @var string $registryLocation */
-        $registryLocation = $input->getOption('ns-registry') ?? '' ?: self::NS_REGISTRY;
+        $registryLocation = $input->getOption('ns-registry') ?: self::NS_REGISTRY;
         /** @var string $destinationPath */
         $destinationPath = $input->getArgument('destination-path');
         /** @var string[] $ignoredLocations */

--- a/src/CLI/OutputObserver.php
+++ b/src/CLI/OutputObserver.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class OutputObserver implements ObserverInterface
 {
-    public function __construct(private OutputInterface $output)
+    public function __construct(private readonly OutputInterface $output)
     {
     }
 

--- a/src/CLI/OutputObserver.php
+++ b/src/CLI/OutputObserver.php
@@ -8,9 +8,9 @@ use PhpCfdi\ResourcesSatXmlGenerator\DownloaderException;
 use PhpCfdi\ResourcesSatXmlGenerator\ObserverInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class OutputObserver implements ObserverInterface
+final readonly class OutputObserver implements ObserverInterface
 {
-    public function __construct(private readonly OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
     }
 

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -22,6 +22,9 @@ final class Downloader implements DownloaderInterface
         $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
+    /**
+     * @throws DownloaderException
+     */
     public function downloadTo(string $source, string $destination): void
     {
         try {

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -12,12 +12,12 @@ use Throwable;
 
 final class Downloader implements DownloaderInterface
 {
-    private HttpClientInterface $httpClient;
+    private readonly HttpClientInterface $httpClient;
 
     /** @var array<string, string> */
     private array $overrides = [];
 
-    public function __construct(private ObserverInterface $observer, ?HttpClientInterface $httpClient = null)
+    public function __construct(private readonly ObserverInterface $observer, ?HttpClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient ?? HttpClient::create();
     }

--- a/src/DownloaderException.php
+++ b/src/DownloaderException.php
@@ -9,9 +9,9 @@ use Throwable;
 
 final class DownloaderException extends Exception
 {
-    private string $source;
+    private readonly string $source;
 
-    private string $destination;
+    private readonly string $destination;
 
     public function __construct(string $source, string $destination, Throwable $previous = null)
     {

--- a/src/Fetcher.php
+++ b/src/Fetcher.php
@@ -12,9 +12,9 @@ use PhpCfdi\ResourcesSatXmlGenerator\Retrievers\XmlRetrievers;
 
 class Fetcher
 {
-    private Downloader $downloader;
+    private readonly Downloader $downloader;
 
-    public function __construct(private ObserverInterface $observer)
+    public function __construct(private readonly ObserverInterface $observer)
     {
         $this->downloader = new Downloader($observer);
     }

--- a/src/Fetcher.php
+++ b/src/Fetcher.php
@@ -10,11 +10,11 @@ use PhpCfdi\ResourcesSatXmlGenerator\NsRegistry\Locations;
 use PhpCfdi\ResourcesSatXmlGenerator\Retrievers\XmlRetriever;
 use PhpCfdi\ResourcesSatXmlGenerator\Retrievers\XmlRetrievers;
 
-class Fetcher
+readonly class Fetcher
 {
-    private readonly Downloader $downloader;
+    private Downloader $downloader;
 
-    public function __construct(private readonly ObserverInterface $observer)
+    public function __construct(private ObserverInterface $observer)
     {
         $this->downloader = new Downloader($observer);
     }

--- a/src/NsRegistry/Locations.php
+++ b/src/NsRegistry/Locations.php
@@ -14,7 +14,7 @@ use Traversable;
 final class Locations implements IteratorAggregate
 {
     /** @var string[] */
-    private array $locations;
+    private readonly array $locations;
 
     public function __construct(string ...$locations)
     {

--- a/src/NsRegistry/Locations.php
+++ b/src/NsRegistry/Locations.php
@@ -11,10 +11,10 @@ use Traversable;
 /**
  * @implements IteratorAggregate<string>
  */
-final class Locations implements IteratorAggregate
+final readonly class Locations implements IteratorAggregate
 {
     /** @var string[] */
-    private readonly array $locations;
+    private array $locations;
 
     public function __construct(string ...$locations)
     {

--- a/src/NsRegistry/NsEntry.php
+++ b/src/NsRegistry/NsEntry.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\ResourcesSatXmlGenerator\NsRegistry;
 
 final class NsEntry
 {
-    public function __construct(private string $xsd, private string $xslt)
+    public function __construct(private readonly string $xsd, private readonly string $xslt)
     {
     }
 

--- a/src/NsRegistry/NsEntry.php
+++ b/src/NsRegistry/NsEntry.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\ResourcesSatXmlGenerator\NsRegistry;
 
-final class NsEntry
+final readonly class NsEntry
 {
-    public function __construct(private readonly string $xsd, private readonly string $xslt)
+    public function __construct(private string $xsd, private string $xslt)
     {
     }
 

--- a/src/NsRegistry/NsRegistry.php
+++ b/src/NsRegistry/NsRegistry.php
@@ -10,7 +10,7 @@ use RuntimeException;
 final class NsRegistry
 {
     /** @var NsEntry[] */
-    private array $entries;
+    private readonly array $entries;
 
     public function __construct(NsEntry ...$entries)
     {

--- a/src/NsRegistry/NsRegistry.php
+++ b/src/NsRegistry/NsRegistry.php
@@ -7,10 +7,10 @@ namespace PhpCfdi\ResourcesSatXmlGenerator\NsRegistry;
 use JsonException;
 use RuntimeException;
 
-final class NsRegistry
+final readonly class NsRegistry
 {
     /** @var NsEntry[] */
-    private readonly array $entries;
+    private array $entries;
 
     public function __construct(NsEntry ...$entries)
     {
@@ -32,7 +32,7 @@ final class NsRegistry
             throw new RuntimeException('Namespace registry contents is not an array of entries', 0, $exception);
         }
         $entries = [];
-        /** @var array<string, string|null> $entry */
+        /** @var array<string, scalar|null> $entry */
         foreach ($baseEntries as $entry) {
             $entries[] = new NsEntry(
                 strval($entry['xsd'] ?? ''),

--- a/src/Retrievers/XmlRetriever.php
+++ b/src/Retrievers/XmlRetriever.php
@@ -9,9 +9,9 @@ use Eclipxe\XmlResourceRetriever\RetrieverInterface;
 final class XmlRetriever
 {
     /** @var string[] */
-    private array $extensions;
+    private readonly array $extensions;
 
-    public function __construct(private RetrieverInterface $retriever, string ...$extensions)
+    public function __construct(private readonly RetrieverInterface $retriever, string ...$extensions)
     {
         $this->extensions = $extensions;
     }

--- a/src/Retrievers/XmlRetriever.php
+++ b/src/Retrievers/XmlRetriever.php
@@ -6,12 +6,12 @@ namespace PhpCfdi\ResourcesSatXmlGenerator\Retrievers;
 
 use Eclipxe\XmlResourceRetriever\RetrieverInterface;
 
-final class XmlRetriever
+final readonly class XmlRetriever
 {
     /** @var string[] */
-    private readonly array $extensions;
+    private array $extensions;
 
-    public function __construct(private readonly RetrieverInterface $retriever, string ...$extensions)
+    public function __construct(private RetrieverInterface $retriever, string ...$extensions)
     {
         $this->extensions = $extensions;
     }

--- a/src/Retrievers/XmlRetrievers.php
+++ b/src/Retrievers/XmlRetrievers.php
@@ -9,7 +9,7 @@ use RuntimeException;
 final class XmlRetrievers
 {
     /** @var XmlRetriever[] */
-    private array $xmlRetrievers;
+    private readonly array $xmlRetrievers;
 
     public function __construct(XmlRetriever ...$xmlRetrievers)
     {

--- a/src/Retrievers/XmlRetrievers.php
+++ b/src/Retrievers/XmlRetrievers.php
@@ -6,10 +6,10 @@ namespace PhpCfdi\ResourcesSatXmlGenerator\Retrievers;
 
 use RuntimeException;
 
-final class XmlRetrievers
+final readonly class XmlRetrievers
 {
     /** @var XmlRetriever[] */
-    private readonly array $xmlRetrievers;
+    private array $xmlRetrievers;
 
     public function __construct(XmlRetriever ...$xmlRetrievers)
     {

--- a/tests/Integration/FakeDownloadTest.php
+++ b/tests/Integration/FakeDownloadTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * into a temporary folder, it expects that all xml files were downloaded.
  *
  * Important:
- *  - Is using local php web server http://localhost:8999/ using tests/_files/public/ as docroot
+ *  - Is using local php web server http://localhost:8999/ using tests/_files/public/ as doc-root
  *  - The temporary created folder is removed on test case tear down
  *  - Is not using the global namespace registry, is using a fake located at http://localhost:8999/registry.json
  */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,7 @@ abstract class TestCase extends PHPUnitTestCase
 
     public function createFolderForTest(): string
     {
+        /** @noinspection SpellCheckingInspection */
         $command = sprintf('mktemp --directory --tmpdir=%s', escapeshellarg($this->localBuildDir()));
         $temporaryFolder = trim(strval(shell_exec($command)));
         if ('' === $temporaryFolder) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,6 @@ call_user_func(function (): void {
     do {
         usleep(10000); // wait 0.01 seconds before each try
         $headers = @get_headers('http://localhost:8999/README.md') ?: [];
-        $httpResponse = $headers[0] ?? '';
+        $httpResponse = strval($headers[0] ?? '');
     } while (! str_contains($httpResponse, '200 OK'));
 });


### PR DESCRIPTION
- Se usa PHP 8.3 como la versión mínima (cambio de versión mayor a 3.0.0)
- Se actualiza la imagen de docker para que esté basada en PHP 8.3.
- Se cambia el archivo de licencia. ¡Feliz 2024!
- Se corrige el ancla del proyecto en el archivo `CONTRIBUTING.md`.
- Se actualiza el archivo de configuración de `php-cs-fixer`.
- Se actualizan los flujos de trabajo de GitHub:
  - Se agrega PHP 8.3 a la matriz de pruebas.
  - Se ejecutan los flujos de trabajo en PHP 8.3.
  - Se permite ejecutar manualmente el flujo de trabajo.
- Se actualizan las herramientas de desarrollo.
