### PR TITLE
Fix Psalm issues and maintenance (Version 3.0.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -64,7 +64,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -110,7 +110,7 @@ jobs:
         php-version: ['8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -123,7 +123,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Psalm version
+        run: psalm --version
       - name: Psalm
         run: psalm --no-progress --output-format=github
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,24 @@ on:
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
 
 jobs:
+
+  composer-normalize:
+    name: Composer normalization
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer-normalize
+        env:
+          fail-fast: true
+      - name: Composer normalize
+        run: composer-normalize
+
   phpcs:
     name: Code style (phpcs)
     runs-on: "ubuntu-latest"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -28,7 +28,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -38,7 +38,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: build/coverage
@@ -73,7 +73,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
@@ -86,7 +86,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -94,7 +94,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
           path: build/coverage

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.8.1" installed="3.8.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.8.1" installed="3.8.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.48.0" installed="3.48.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.10.56" installed="1.10.56" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.20.0" installed="5.20.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpcs" version="^3.9.2" installed="3.9.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.2" installed="3.9.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.57.1" installed="3.57.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.11.1" installed="1.11.1" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.24.0" installed="5.24.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -5,4 +5,5 @@
   <phar name="php-cs-fixer" version="^3.57.1" installed="3.57.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpstan" version="^1.11.1" installed="1.11.1" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="^5.24.0" installed="5.24.0" location="./tools/psalm" copy="false"/>
+  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,12 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
+            "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
+            "@php tools/composer-normalize normalize",
             "@php tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
@@ -58,8 +60,8 @@
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
-        "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
-        "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
+        "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
         "dev:test": "DEV: run dev:check-style, phpunit, phpstan and psalm",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.17",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.1.3",
         "symfony/finder": "^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,32 @@
 {
     "name": "phpcfdi/resources-sat-xml-generator",
     "description": "Generates XSD and XSLT from SAT",
-    "keywords": ["mexico", "sat"],
-    "homepage": "https://github.com/phpcfdi/resources-sat-xml-generator",
     "license": "MIT",
+    "keywords": [
+        "mexico",
+        "sat"
+    ],
     "authors": [
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com"
         }
     ],
+    "homepage": "https://github.com/phpcfdi/resources-sat-xml-generator",
     "support": {
-        "source": "https://github.com/phpcfdi/resources-sat-xml-generator",
-        "issues": "https://github.com/phpcfdi/resources-sat-xml-generator/issues"
+        "issues": "https://github.com/phpcfdi/resources-sat-xml-generator/issues",
+        "source": "https://github.com/phpcfdi/resources-sat-xml-generator"
     },
     "require": {
         "php": ">=8.3",
         "ext-json": "*",
         "eclipxe/xmlresourceretriever": "^2.0.1",
-        "symfony/http-client": "^7.0",
-        "symfony/console": "^7.0"
+        "symfony/console": "^7.0",
+        "symfony/http-client": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
         "fakerphp/faker": "^1.17",
+        "phpunit/phpunit": "^10.5",
         "symfony/finder": "^7.0"
     },
     "autoload": {
@@ -37,11 +40,17 @@
         }
     },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": [
+            "@dev:fix-style",
+            "@dev:test"
+        ],
         "dev:check-style": [
             "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
+        ],
+        "dev:coverage": [
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
             "@php tools/composer-normalize normalize",
@@ -53,16 +62,13 @@
             "@php vendor/bin/phpunit --testdox --stop-on-failure",
             "@php tools/phpstan analyse --no-progress",
             "@php tools/psalm --no-progress"
-        ],
-        "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:check-style, phpunit, phpstan and psalm",
-        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
+        "dev:test": "DEV: run dev:check-style, phpunit, phpstan and psalm"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,19 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Importante: **Cambiar la versión en `Application::__construct`**. 
 
+## Versión 3.0.1 2024-05-15
+
+- Se corrige el problema encontrado por Psalm poniendo el tipo apropiado en la constante `NS_REGISTRY`.
+
+Actualizaciones de mantenimiento:
+
+- Se actualiza PHPUnit a la versión 11.
+- Se actualizan las acciones de GitHub a versión 4.
+- Se remueven las rutas fijas en la ejecución del flujo de trabajo `phpcs`.
+- Se muestra la versión de Psalm en el flujo de trabajo pues no se muestra en la instalación.
+- Se agrega la herramienta `composer-normalize` a las herramientas de desarrollo.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 3.0.0 2024-01-22
 
 - Se actualiza la versión mínima de PHP a 8.3.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,24 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    cacheDirectory="build/phpunit"
+    bootstrap="tests/bootstrap.php"
     colors="true"
-    bootstrap="./tests/bootstrap.php"
-    cacheResultFile="build/phpunit.result.cache">
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    >
     <testsuites>
         <testsuite name="Default">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory>src</directory>
         </include>
     </source>
 </phpunit>

--- a/src/CLI/FetchSatCommand.php
+++ b/src/CLI/FetchSatCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class FetchSatCommand extends Command
 {
-    public const NS_REGISTRY = 'https://raw.githubusercontent.com/phpcfdi/sat-ns-registry/master/complementos_v1.json';
+    public const string NS_REGISTRY = 'https://raw.githubusercontent.com/phpcfdi/sat-ns-registry/master/complementos_v1.json';
 
     /** @noinspection PhpMissingParentCallCommonInspection */
     public static function getDefaultName(): string


### PR DESCRIPTION
- Se corrige el problema encontrado por Psalm poniendo el tipo apropiado en la constante `NS_REGISTRY`.

Actualizaciones de mantenimiento:

- Se actualiza PHPUnit a la versión 11.
- Se actualizan las acciones de GitHub a versión 4.
- Se remueven las rutas fijas en la ejecución del flujo de trabajo `phpcs`.
- Se muestra la versión de Psalm en el flujo de trabajo pues no se muestra en la instalación.
- Se agrega la herramienta `composer-normalize` a las herramientas de desarrollo.
- Se actualizan las herramientas de desarrollo.